### PR TITLE
typos

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -496,7 +496,7 @@
   </p>
 
   <p>
-    For the attribute vector to work requires that taking any starting
+    For the attribute vector to work that requires taking any starting
     font, we can construct the corresponding bold version by adding
     the <em>same</em> vector in the latent space.  However, <em>a
     priori</em> there is no reason using a single constant vector to
@@ -992,7 +992,7 @@
     information-theoretic ideas to find structure in the latent
     space.)  Ideally, such models would start to get at true
     explanations, not just in a static form, but in a dynamic form,
-    manipulable by the user.  But we're a long way from that point.
+    manipulable by the user.  But we're a long way to that point.
   </p>
 
   <h2>


### PR DESCRIPTION
During the translation of aia to [Chinese][1],
I suspect I have found two typos in the original text.
Not a native English speaker thus I am unsure
if they are typos or just because I am not familiar with English grammar.

[1]: https://www.jqr.com/news/009092