### PR TITLE
"You can't have it both ways.".

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -809,7 +809,7 @@
     relatively banal example, such
     as <em>Photoshop</em>. Adept <em>Photoshop</em> users routinely
     have formerly impossible thoughts such as: &ldquo;let's apply the
-    clone stamp to the such-and-such layer.&rdquo;.  That's an
+    clone stamp to the such-and-such layer&rdquo;.  That's an
     instance of a more general class of thought: &ldquo;computer, [new
     type of action] this [new type of representation for a newly
     imagined class of object]&rdquo;. When that happens, we're using


### PR DESCRIPTION
Dear Michael and Shan,

I respect the tradeoffs between American and British quoting styles. On the one hand, I find the British style to be more logical, closer to the syntax you would expect in a compiled language. On the other hand, and perhaps due only to my upbringing, I think the American style looks better, the way punctuation snuggles into the end fo the sentence like that, tucked neatly into the curved quotes.

But this double period simply will not do. I've applied the British style for consistency with the rest of the piece.

Your correspondent,

R.M.O.